### PR TITLE
samples: remove redundant (and incorrect) entry

### DIFF
--- a/applications/nrf5340_audio/sample.yaml
+++ b/applications/nrf5340_audio/sample.yaml
@@ -5,7 +5,6 @@ common:
   integration_platforms:
     - nrf5340_audio_dk/nrf5340/cpuapp
   platform_allow: nrf5340_audio_dk/nrf5340/cpuapp
-  platform_exclude: nrf5340_audio_dk/nrf5340/cpuapp_ns
   sysbuild: true
   build_only: true
   tags: ci_build sysbuild

--- a/samples/bluetooth/nrf_auraconfig/sample.yaml
+++ b/samples/bluetooth/nrf_auraconfig/sample.yaml
@@ -5,7 +5,6 @@ common:
   integration_platforms:
     - nrf5340_audio_dk/nrf5340/cpuapp
   platform_allow: nrf5340_audio_dk/nrf5340/cpuapp
-  platform_exclude: nrf5340_audio_dk/nrf5340/cpuapp_ns
   sysbuild: true
   build_only: true
   tags: ci_build sysbuild bluetooth


### PR DESCRIPTION
Platform_allow already superseeds platform_exclude. Also, it should be nrf5340_audio_dk/nrf5340/cpuapp/ns not nrf5340_audio_dk/nrf5340/cpuapp_ns if needed.